### PR TITLE
fix: maker dsr dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 checksum_dict>=1.1.2
 dank_mids>=4.20.36
 eth_retry>=0.1.15,<1
-ez-a-sync>=0.11.2
+ez-a-sync>=0.12.1
 pandas>=1.4.3,<1.6
 ypricemagic>=2.14.1


### PR DESCRIPTION
requires ez-a-sync>=0.12.1