### PR TITLE
feat: unblock _get_and_yield iterator

### DIFF
--- a/eth_portfolio/_ledgers/address.py
+++ b/eth_portfolio/_ledgers/address.py
@@ -184,7 +184,7 @@ class AddressLedgerBase(
             num_yielded += 1
             if num_yielded % 1000 == 0:
                 await asyncio.sleep(0)
-            
+
         if self.objects and end_block and self.objects[-1].block_number > end_block:
             for object in self.objects:
                 block = obj.block_number
@@ -194,7 +194,7 @@ class AddressLedgerBase(
                     return
                 yield obj
                 await unblock_loop()
-        
+
         yielded = set()
         for obj in self.objects:
             block = obj.block_number
@@ -589,7 +589,9 @@ class AddressInternalTransfersLedger(AddressLedgerBase[InternalTransfersList, In
             self.cached_thru = end_block
 
 
-_yield_tokens_semaphore = a_sync.Semaphore(10, name="eth_portfolio._ledgers.address._yield_tokens_semaphore")
+_yield_tokens_semaphore = a_sync.Semaphore(
+    10, name="eth_portfolio._ledgers.address._yield_tokens_semaphore"
+)
 
 
 class TokenTransfersList(PandableList[TokenTransfer]):

--- a/eth_portfolio/protocols/lending/maker.py
+++ b/eth_portfolio/protocols/lending/maker.py
@@ -58,7 +58,7 @@ class Maker(LendingProtocolWithLockedCollateral):
     async def _debt(self, address: Address, block: Optional[int] = None) -> TokenBalances:
         if block is not None and block <= await contract_creation_block_async(self.ilk_registry):
             return TokenBalances(block=block)
-            
+
         ilks, urn = await asyncio.gather(self.get_ilks(block), self._urn(address))
 
         data = await asyncio.gather(

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,7 @@ setup(
     author_email="bobthebuidlerdefi@gmail.com",
     url="https://github.com/BobTheBuidler/eth-portfolio",
     install_requires=requirements,
-    setup_requires=[
-        "setuptools_scm", "cython"
-    ],
+    setup_requires=["setuptools_scm", "cython"],
     package_data={
         "eth_portfolio": ["py.typed"],
     },


### PR DESCRIPTION
Previously blocked the event loop if called for an address+period with many consecutive results cached in local db