### PR TITLE
fix: remove node exporter

### DIFF
--- a/eth_portfolio_scripts/docker/docker-compose.yaml
+++ b/eth_portfolio_scripts/docker/docker-compose.yaml
@@ -65,13 +65,3 @@ services:
     networks:
       - eth_portfolio
     restart: always
-
-  node-exporter:
-    image: quay.io/prometheus/node-exporter:latest
-    command:
-      - "--path.rootfs=/host"
-    networks:
-      - eth_portfolio
-    volumes:
-      - "/:/host:ro,rslave"
-    restart: always


### PR DESCRIPTION
it needs privileged access on macos (maybe windows too) and isn't actually a requirement for eth-portfolio or its services

user can run their own deployment if desired