### PR TITLE
fix: decrease get_block_at_timestamp concurrency 100 -> 50

### DIFF
--- a/eth_portfolio_scripts/_portfolio.py
+++ b/eth_portfolio_scripts/_portfolio.py
@@ -36,7 +36,7 @@ log_debug: Final = logger.debug
 log_error: Final = logger.error
 
 _block_at_timestamp_semaphore: Final = a_sync.Semaphore(
-    100, name="eth-portfolio get_block_at_timestamp"
+    50, name="eth-portfolio get_block_at_timestamp"
 )
 
 


### PR DESCRIPTION
We were getting too many "database is locked" errors and the retries were getting locked too