### PR TITLE
fix(cicd): build release sdists with PEP 517

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -153,13 +153,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine mypy[mypyc] types-aiofiles
+          python -m pip install "setuptools>=80" wheel build twine "mypy[mypyc]" types-aiofiles
 
       - name: Build sdist
         env:
           # Use version from git tag (stripped 'v')
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.get_version.outputs.version }}
-        run: python setup.py sdist
+        run: python -m build --sdist
 
       # ----------------------------------------------------
       # Download wheels built on each runner
@@ -199,6 +199,17 @@ jobs:
         with:
           name: "wheels-windows-latest-x86"
           path: wheelhouse/windows-x86
+
+      - name: Check distributions
+        run: |
+          python -m twine check \
+            dist/* \
+            wheelhouse/linux-many-x64/*.whl \
+            wheelhouse/linux-many-x86/*.whl \
+            wheelhouse/linux-musl-x64/*.whl \
+            wheelhouse/macos/*.whl \
+            wheelhouse/windows-x64/*.whl \
+            wheelhouse/windows-x86/*.whl
 
       # ----------------------------------------------------
       # Publish sdist and wheels to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
-    "setuptools",
+    "setuptools>=80",
     "wheel",
+    "setuptools-scm>=8,<11",
     "mypy[mypyc]==2.1.0",
     "pandas-stubs==2.3.3.260113; python_version < '3.11'",
     "pandas-stubs==3.0.0.260204; python_version >= '3.11'",
@@ -17,6 +18,11 @@ requires = [
     "faster-async-lru==2.0.5.3",
     "typed-envs==0.2.4",
 ]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+version_scheme = "python-simplified-semver"
 
 [tool.mypy]
 exclude = ["build/","cache/","env/"]

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,12 @@ To install the `eth-portfolio` package, you should start with a fresh virtual en
 Due to the use of :mod:`setuptools_scm` for versioning, it is recommended to clone the repository first
 to ensure the version can be determined correctly.
 
-The `setup.py` file automatically handles the installation of :mod:`setuptools_scm` and :mod:`cython`,
-so you do not need to install them manually before running the setup process. Additionally,
-the `requirements.txt` file is used to specify additional dependencies that are installed via
-the `install_requires` parameter. Note that the last line of `requirements.txt` is intentionally excluded
-from installation, so ensure that any necessary dependency is not placed on the last line.
+Build requirements are declared in :mod:`pyproject.toml` and installed by PEP 517 frontends such as
+:mod:`pip` or :mod:`build`, so you do not need to install them manually before running the setup
+process. Additionally, the `requirements.txt` file is used to specify additional dependencies that are
+installed via the `install_requires` parameter. Note that the last line of `requirements.txt` is
+intentionally excluded from installation, so ensure that any necessary dependency is not placed on the
+last line.
 
 Example:
     .. code-block:: bash
@@ -110,18 +111,12 @@ setup(
     name="eth_portfolio",
     python_requires=">=3.10,<3.14",
     packages=find_packages(),
-    use_scm_version={
-        "root": ".",
-        "relative_to": __file__,
-        "local_scheme": "no-local-version",
-        "version_scheme": "python-simplified-semver",
-    },
+    use_scm_version=True,
     description="eth-portfolio makes it easy to analyze your portfolio.",
     author="BobTheBuidler",
     author_email="bobthebuidlerdefi@gmail.com",
     url="https://github.com/BobTheBuidler/eth-portfolio",
     install_requires=requirements,
-    setup_requires=["setuptools_scm"],
     package_data={
         "eth_portfolio": ["py.typed"],
         "eth_portfolio_scripts": ["py.typed"],


### PR DESCRIPTION
## Summary

Switch release sdist creation from legacy `python setup.py sdist` to a PEP 517 build flow.

## Rationale

The failed release job loaded `setuptools_scm` through deprecated `setup_requires`, which allowed `setuptools_scm` to import before its `vcs-versioning` dependency was available. Declaring the build backend and build requirements in `pyproject.toml` makes build dependency resolution explicit and isolated before package metadata is evaluated.

## Details

- Add `setuptools.build_meta`, `setuptools>=80`, and bounded `setuptools-scm>=8,<11` build metadata.
- Move setuptools-scm scheme settings to `[tool.setuptools_scm]` and keep `use_scm_version=True` as the setup opt-in.
- Remove `setup_requires=["setuptools_scm"]` from `setup.py`.
- Install `build` in the publish job, build the sdist with `python -m build --sdist`, and run `twine check` before upload.

## Tests

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.5.20 python3 -m build --sdist`
- `.twine-venv/bin/python -m twine check dist/*`
- `.smoke-venv/bin/python -m pip install dist/eth_portfolio-0.5.20.tar.gz`
- `/tmp/eth-portfolio-pep517/.smoke-venv/bin/python -c "from importlib.metadata import version; print(version('eth-portfolio'))"` -> `0.5.20`
- Confirmed compiled mypyc extensions installed under `.smoke-venv/lib/python3.12/site-packages/eth_portfolio/*.so`.

Note: `twine check` passed with pre-existing metadata warnings for missing `long_description` and `long_description_content_type`.